### PR TITLE
Enhancement build readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ pip install nrfutil
 
 ## Install nrfjprog
 nrfjprog is required to flash/debug the nRF52840 development kit (in this case: the display). Download the tool 
-(here)[https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download].
+[here](https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download).
 Debian based systems may install the `.deb` package via
 ```
 sudo dpkg -i <nrf-debian-package-name>.deb
 ```
 
 nrfjprog requires SEGGER's JLink Software in order to run. Download the appropriate installer for
-your system (here)[https://www.segger.com/downloads/jlink].
+your system [here](https://www.segger.com/downloads/jlink).
 As in the previous step, Debian based systems may use the `.deb` and install it the same way as above.
 
 ## Adding the user to the dialout group


### PR DESCRIPTION
Updated Readme as follows:

- Where to get nrfjprog and how to install it on debian 
- Where to get SEGGER JLink Software and how to install it on debian

Both are required to build and flash the Nordic nRF52840-DK.