### PR TITLE
Enhancement udev issue makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ LED will light up. Then call:
 make dongle
 ```
 
+## Issues
+Sometimes the udev rule won't work and `ttyDisplayDongle` won't show up
+in `/dev/`. In that case uncomment the section at the very bottom
+in `app/Makefile`.
+

--- a/app/Makefile
+++ b/app/Makefile
@@ -46,4 +46,7 @@ build-dongle:
         --application-version 1 dongle-build/dongle.zip
 
 flash-dongle:
+	# Uncomment the following two lines if /dev/ttyDisplayDongle won't show up after setting udev rule
+	# sudo touch /dev/ttyDisplayDongle
+	# sudo chmod 777 /dev/ttyDisplayDongle
 	nrfutil dfu usb-serial -pkg dongle-build/dongle.zip -p /dev/ttyDisplayDongle


### PR DESCRIPTION
Makefile:
- When flashing to dongle `ttyDisplayDongle` won't always show up. Added a few lines to force its creation. Feels like a nasty hack but it does work (on my machine). More testing required!